### PR TITLE
Fix error for M1 mac not being able to run the docker containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   chrome:
+    platform: linux/x86_64
     build:
       context: chrome/
     #ports:
@@ -15,6 +16,7 @@ services:
       - 5000:1024
 
   admin:
+    platform: linux/x86_64
     build:
       context: admin/
     depends_on:


### PR DESCRIPTION
I was running into this error when trying to run the docker containers:

`e: unable to locate package google-chrome-stable`

I'm not a Docker expert, but this PR seems to fix the issue. I might be completely off here, but I assume it picks a debian image for ARM by default, as the macbook is running an M1 processor, if platform parameter is not being set. That causes the installation to fail (as there are no ARM versions for chrome, seemingly).

After adding said parameters, everything installed and runs without a hitch.